### PR TITLE
Fix .search-box painted over rounded border

### DIFF
--- a/public/public/css/local.css
+++ b/public/public/css/local.css
@@ -413,6 +413,7 @@ td.rdtYear:hover {
   font-size: 1rem;
   line-height: 1.5;
   color: #495057;
+  background: none;
 }
 
 .form-control {


### PR DESCRIPTION
The background of .search-box was painted on top of the rounded border of .search.
Fixed by setting the background to none.